### PR TITLE
Rename to swift-devcontainer-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ Given how frequently web applications use Node.js for front end code, this conta
 
 Copyright (c) Visual Studio Code Swift extension project. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/swift-server/swift-dev-container/blob/main/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/swift-server/swift-devcontainer-template/blob/main/LICENSE).

--- a/src/swift/devcontainer-template.json
+++ b/src/swift/devcontainer-template.json
@@ -3,16 +3,16 @@
 	"version": "1.1.0",
 	"name": "Swift",
 	"description": "Develop Swift based applications. Includes appropriate runtime args and everything you need to get up and running.",
-	"documentationURL": "https://github.com/swift-server/swift-dev-container/tree/main/README.md",
+	"documentationURL": "https://github.com/swift-server/swift-devcontainer-template/tree/main/README.md",
 	"publisher": "Swift Server Work Group",
-	"licenseURL": "https://github.com/swift-server/swift-dev-container/blob/main/LICENSE",
+	"licenseURL": "https://github.com/swift-server/swift-devcontainer-template/blob/main/LICENSE",
 	"options": {
 		"imageVariant": {
 			"type": "string",
 			"description": "Swift version:",
 			"proposals": [
 				"5.7",
-				"5.6-focal",
+				"5.6",
 				"5.5",
 				"5.4",
 				"5.3",

--- a/src/swift/devcontainer-template.json
+++ b/src/swift/devcontainer-template.json
@@ -12,7 +12,7 @@
 			"description": "Swift version:",
 			"proposals": [
 				"5.7",
-				"5.6",
+				"5.6-focal",
 				"5.5",
 				"5.4",
 				"5.3",


### PR DESCRIPTION
This is more consistent with other dev container repos
It also allows for us to have a swift-devcontainer-features repo at a later date