### PR TITLE
Support for Swift 5.10 docker image, when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Develop Swift based applications. Includes everything you need to get up and run
 
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
-| imageVariant | Version of Swift | string | 5.9 |
+| imageVariant | Version of Swift | string | 5.10 |
 
 This template uses the common-utils feature to implement some commonly implemented options including install zsh and updating packages. Edit the values in the `devcontainer.json` to enable these. More details on available options can be found [here](https://github.com/devcontainers/features/blob/main/src/common-utils/README.md). 
 

--- a/src/swift/devcontainer-template.json
+++ b/src/swift/devcontainer-template.json
@@ -11,6 +11,7 @@
 			"type": "string",
 			"description": "Swift version:",
 			"proposals": [
+				"5.10",
 				"5.9",
 				"5.8",
 				"5.7",
@@ -21,7 +22,7 @@
 				"5.2",
 				"5.1"
 			],
-			"default": "5.9"
+			"default": "5.10"
 		}
 	},
 	"platforms": [


### PR DESCRIPTION
Adds support for Swift 5.10 docker image, and sets that to the default on new dev containers.

Blocked by https://github.com/apple/swift-docker/pull/372