### PR TITLE
Update version number and remove useless swift --version call

### DIFF
--- a/src/swift/.devcontainer/devcontainer.json
+++ b/src/swift/.devcontainer/devcontainer.json
@@ -36,9 +36,6 @@
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],
 
-    // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "swift --version",
-
     // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "vscode"
 }

--- a/src/swift/devcontainer-template.json
+++ b/src/swift/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
 	"id": "swift",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"name": "Swift",
 	"description": "Develop Swift based applications. Includes everything you need to get up and running.",
 	"documentationURL": "https://github.com/swift-server/swift-devcontainer-template/tree/main/README.md",


### PR DESCRIPTION
Update version number for 5.10 update
Also remove `swift --version` call as it creates an unnecessary terminal and any new terminal window opened already details the swift version